### PR TITLE
Fix leaky seravo-postbox padding styles

### DIFF
--- a/style/seravo-postbox.css
+++ b/style/seravo-postbox.css
@@ -4,7 +4,7 @@
   }
 }
 @media only screen and (max-width:1445px) {
-  .inside {
+  .seravo-postbox .inside {
     padding: 10px 20px 20px 20px!important;
   }
 }


### PR DESCRIPTION
Padding from `.inside` class affects all postboxes, adding unnecessary padding to multiple places in the admin, the Publish-postbox for example. These styles are probably meant for seravo-postboxes only. Or maybe this css-file should only be enqueued on seravo-plugin pages?

There are similar risky styles in `seravo-plugin/style/updates.css` but apparently those styles are loaded only on the Updates-page.